### PR TITLE
Fix warnings and check for error return codes

### DIFF
--- a/SUIDGuard/SUIDGuard.c
+++ b/SUIDGuard/SUIDGuard.c
@@ -15,6 +15,7 @@
 #include <sys/malloc.h>
 #include <sys/imgact.h>
 #include <sys/proc.h>
+#include <sys/systm.h>
 #define CONFIG_MACF 1
 #include <security/mac_framework.h>
 #include <security/mac.h>
@@ -127,7 +128,7 @@ exit:
         vfs_context_rele(ctx);
     }
     
-    return 0;
+    return error;
 }
 
 
@@ -198,11 +199,11 @@ kern_return_t SUIDGuard_stop(kmod_info_t *ki, void *d);
 kern_return_t SUIDGuard_start(kmod_info_t * ki, void *d)
 {
     int r = mac_policy_register(&suidguard_policy_conf, &suidguard_handle, d);
-    return KERN_SUCCESS;
+    return r == 0 ? KERN_SUCCESS : KERN_FAILURE;
 }
 
 kern_return_t SUIDGuard_stop(kmod_info_t *ki, void *d)
 {
-    mac_policy_unregister(suidguard_handle);
-    return KERN_SUCCESS;
+    int r = mac_policy_unregister(suidguard_handle);
+    return r == 0 ? KERN_SUCCESS : KERN_FAILURE;
 }


### PR DESCRIPTION
Hi,

I added the `sys/systm.h` include, otherwise the compiler complains about printf, etc.
Also, you did always return 0 in `suidguard_cred_label_update_execve` although a return variable called `error` existed.
Finally, I added a check for mac_policy_(un)register's return values and return `KERN_SUCCESS` only if they return 0.

Anyway, nice work!

Cheers,
Clemens

Signed-off-by: Clemens Gruber clemensgru@gmail.com
